### PR TITLE
Add tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,25 @@
+language: julia
+
+os:
+  - osx
+  - linux
+
+julia:
+  - 0.6
+  - 0.7
+  - nightly
+
+matrix:
+  allow_failures:
+  - julia: nightly
+
+notifications:
+  email: false
+
+#script: # the default script is equivalent to the following
+#  - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
+#  - julia -e 'using Pkg; Pkg.clone(pwd()); Pkg.build("Stats"); Pkg.test("Stats"; coverage=true)';
+
+after_success:
+#  - julia -e 'using Pkg; cd(Pkg.dir("Stats")); Pkg.add("Coverage"); using Coverage; Coveralls.submit(Coveralls.process_folder())';
+#  - julia -e 'using Pkg; cd(Pkg.dir("Stats")); Pkg.add("Coverage"); using Coverage; Codecov.submit(Codecov.process_folder())';

--- a/README.md
+++ b/README.md
@@ -6,7 +6,8 @@ This is a convenience meta-package which allows loading essential packages for s
 using Stats
 ```
 
-Currently included packages are:
+Currently this loads the [Statistics](https://docs.julialang.org/en/stable/stdlib/Statistics/)
+standard library module, and the following packages:
 * [Bootstrap](https://github.com/juliangehring/Bootstrap.jl)
 * [CategoricalArrays](https://github.com/JuliaData/CategoricalArrays.jl)
 * [Clustering](https://github.com/JuliaStats/Clustering.jl)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 Stats.jl
 ========
 
+[![Build Status](https://travis-ci.org/JuliaStats/Stats.jl.svg?branch=master)](https://travis-ci.org/JuliaStats/Stats.jl)
+
 This is a convenience meta-package which allows loading essential packages for statistics in one command:
 ```julia
 using Stats

--- a/src/Stats.jl
+++ b/src/Stats.jl
@@ -12,6 +12,7 @@ module Stats
     @reexport using KernelDensity
     @reexport using Loess
     @reexport using MultivariateStats
+    @reexport using Statistics
     @reexport using StatsBase
     @reexport using TimeSeries
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,0 +1,10 @@
+using Stats
+
+# Run all tests in the same process to check that they pass when all
+# packages are loaded at the same time
+for m in [Bootstrap, CategoricalArrays, Clustering, CSV, DataFrames,
+          Distances, Distributions, GLM, HypothesisTests, KernelDensity,
+          Loess, MultivariateStats, Statistics, StatsBase, TimeSeries]
+    println("Testing $m...")
+    include(joinpath(dirname(pathof(m)), "..", "test", "runtests.jl"))
+end


### PR DESCRIPTION
These can check that loading all dependent packages are the same time does not create
conflicts in function names.